### PR TITLE
Add char to `NoSuchGlyph` error message and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "hershey"
-version = "0.1.2"
+version = "0.1.1"
 edition = "2021"
 
 license = "Apache-2.0 OR LGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "hershey"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 license = "Apache-2.0 OR LGPL-3.0"
@@ -13,5 +13,5 @@ repository = "https://github.com/kicad-rs/hershey"
 include = ["src/**/*", "LICENSE*"]
 
 [dependencies]
-itertools = "0.10.3"
-thiserror = "1.0"
+itertools = "0.14"
+thiserror = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub struct NoSuchGlyph(char);
 
 impl Debug for NoSuchGlyph {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		write!(f, "NoSuchGlyph")
+		f.debug_tuple("NoSuchGlyph").field(&self.0).finish()
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,11 @@ pub struct Font<'a> {
 
 #[derive(Clone, Copy, Error)]
 #[error("no such glyph")]
-pub struct NoSuchGlyph(());
+pub struct NoSuchGlyph;
 
 impl Debug for NoSuchGlyph {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		f.debug_tuple("NoSuchGlyph").finish()
+		write!(f, "NoSuchGlyph")
 	}
 }
 
@@ -49,7 +49,7 @@ impl<'a> Font<'a> {
 
 	pub fn glyph(&self, ch: char) -> Result<Glyph, NoSuchGlyph> {
 		let idx = ch as usize - self.offset;
-		let data = self.data.get(idx).ok_or(NoSuchGlyph(()))?;
+		let data = self.data.get(idx).ok_or(NoSuchGlyph)?;
 
 		let mut glyph = Glyph {
 			vectors: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,10 @@ pub struct Font<'a> {
 	offset: usize
 }
 
+/// The requested glyph with character code could not be found.
 #[derive(Clone, Copy, Error)]
-#[error("no such glyph")]
-pub struct NoSuchGlyph;
+#[error("no such glyph {}", .0)]
+pub struct NoSuchGlyph(char);
 
 impl Debug for NoSuchGlyph {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -49,7 +50,7 @@ impl<'a> Font<'a> {
 
 	pub fn glyph(&self, ch: char) -> Result<Glyph, NoSuchGlyph> {
 		let idx = ch as usize - self.offset;
-		let data = self.data.get(idx).ok_or(NoSuchGlyph)?;
+		let data = self.data.get(idx).ok_or(NoSuchGlyph(ch))?;
 
 		let mut glyph = Glyph {
 			vectors: Vec::new(),


### PR DESCRIPTION
This patch adds character code to `NoSuchGlyph` so the error is more descriptive.
It also updates dependencies:
- `itertools = "0.10.3"` -> `itertools = "0.14"`
- `thiserror = "1.0"` -> `thiserror = "2.0"`